### PR TITLE
Fix some things so "mvn clean install" tycho build works

### DIFF
--- a/org.dadacoalition.yedit.feature/feature.xml
+++ b/org.dadacoalition.yedit.feature/feature.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
-      id="org.dadacoalition.yedit"
+      id="org.dadacoalition.yedit.feature"
       label="YEdit Feature"
-      version="1.0.16"
+      version="1.0.17.qualifier"
       provider-name="YEdit Project">
 
    <description>
@@ -118,7 +118,7 @@ This Agreement is governed by the laws of the State of New York and the intellec
          id="org.dadacoalition.yedit"
          download-size="0"
          install-size="0"
-         version="1.0.16"
+         version="0.0.0"
          unpack="false"/>
 
 </feature>

--- a/org.dadacoalition.yedit.feature/pom.xml
+++ b/org.dadacoalition.yedit.feature/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.dadacoalition.yedit</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.12</version>
+    <version>1.0.17-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.dadacoalition.yedit.feature</artifactId>

--- a/org.dadacoalition.yedit.update/.gitignore
+++ b/org.dadacoalition.yedit.update/.gitignore
@@ -2,3 +2,4 @@
 /plugins
 /artifacts.jar
 /content.jar
+/target

--- a/org.dadacoalition.yedit.update/pom.xml
+++ b/org.dadacoalition.yedit.update/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.dadacoalition.yedit</groupId>
+		<artifactId>parent</artifactId>
+		<version>1.0.17-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>org.dadacoalition.yedit.site</artifactId>
+	<packaging>eclipse-update-site</packaging>
+
+</project>

--- a/org.dadacoalition.yedit.update/site.xml
+++ b/org.dadacoalition.yedit.update/site.xml
@@ -3,7 +3,7 @@
    <description url="http://dadacoalition.org/yedit">
       YEdit is an editor for editing YAML files. It is implemented as an Eclipse plugin.
    </description>
-   <feature url="features/org.dadacoalition.yedit_1.0.16.jar" id="org.dadacoalition.yedit" version="1.0.16">
+   <feature url="features/org.dadacoalition.yedit_0.0.0.jar" id="org.dadacoalition.yedit" version="0.0.0">
       <category name="YEdit"/>
    </feature>
    <category-def name="YEdit" label="YEdit"/>

--- a/org.dadacoalition.yedit.update/site.xml
+++ b/org.dadacoalition.yedit.update/site.xml
@@ -3,7 +3,7 @@
    <description url="http://dadacoalition.org/yedit">
       YEdit is an editor for editing YAML files. It is implemented as an Eclipse plugin.
    </description>
-   <feature url="features/org.dadacoalition.yedit_0.0.0.jar" id="org.dadacoalition.yedit" version="0.0.0">
+   <feature url="features/org.dadacoalition.yedit.feature_0.0.0.jar" id="org.dadacoalition.yedit.feature" version="0.0.0">
       <category name="YEdit"/>
    </feature>
    <category-def name="YEdit" label="YEdit"/>

--- a/org.dadacoalition.yedit/META-INF/MANIFEST.MF
+++ b/org.dadacoalition.yedit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: YEdit YAML editor
 Bundle-SymbolicName: org.dadacoalition.yedit;singleton:=true
-Bundle-Version: 1.0.16
+Bundle-Version: 1.0.17.qualifier
 Bundle-Activator: org.dadacoalition.yedit.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.dadacoalition.yedit/pom.xml
+++ b/org.dadacoalition.yedit/pom.xml
@@ -7,11 +7,10 @@
   <parent>
     <groupId>org.dadacoalition.yedit</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.12</version>
+    <version>1.0.17-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.dadacoalition.yedit</artifactId>
   <packaging>eclipse-plugin</packaging>
-
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.dadacoalition.yedit</groupId>
   <artifactId>parent</artifactId>
-  <version>0.0.12</version>
+  <version>1.0.17-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -18,10 +18,15 @@
      <layout>p2</layout>
      <url>http://download.eclipse.org/releases/indigo</url>
    </repository>	
+   <repository>
+     <id>orbit</id>
+     <layout>p2</layout>
+     <url>http://download.eclipse.org/tools/orbit/downloads/drops/R20150124073747/repository/</url>
+   </repository>	
   </repositories>
 
   <properties>
-    <tycho-version>0.15.0</tycho-version>
+    <tycho-version>0.22.0</tycho-version>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
   <modules>
     <module>org.dadacoalition.yedit</module>
     <module>org.dadacoalition.yedit.feature</module>
+    <module>org.dadacoalition.yedit.update</module>
   </modules>
 
   <repositories>


### PR DESCRIPTION
Made a few changes so the tycho build runs and builds update site.

One change is a little quesrionable, namely I changed the feature name because tycho wants feature name and artifact-id to match. But unfurtunately you can't give a feature and a plugin the same id, so I had no choice but to change the feature name.

This might be confusing to people who have the old feature installed and trying to update.
